### PR TITLE
Harden UI audit: fix a11y gaps and stabilize client hook behavior

### DIFF
--- a/app/settings/profile/page.tsx
+++ b/app/settings/profile/page.tsx
@@ -177,9 +177,9 @@ export default function EditProfilePage() {
             <div className="flex items-center gap-4">
               <div className="w-20 h-20 rounded-full overflow-hidden border border-white/10 bg-slate-900/40">
                 {avatarPreviewUrl ? (
-                  <img className="w-full h-full object-cover" src={avatarPreviewUrl} />
+                  <img className="w-full h-full object-cover" src={avatarPreviewUrl} alt="Profile avatar preview" />
                 ) : avatarUrl ? (
-                  <img className="w-full h-full object-cover" src={avatarUrl} />
+                  <img className="w-full h-full object-cover" src={avatarUrl} alt="Current profile avatar" />
                 ) : (
                   <div className="w-full h-full flex items-center justify-center text-slate-500 text-xs">No avatar</div>
                 )}

--- a/components/ModelRevisionsManager.tsx
+++ b/components/ModelRevisionsManager.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { MODEL_ACCEPT_ATTRIBUTE, MODEL_FILE_LABEL } from '@/lib/model-files'
 
 type RevisionEntry = {
@@ -17,7 +17,7 @@ export default function ModelRevisionsManager({ modelId }: { modelId: string }) 
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const load = async () => {
+  const load = useCallback(async () => {
     try {
       const res = await fetch(`/api/models/${modelId}/revisions`, { cache: 'no-store' })
       if (!res.ok) return
@@ -26,11 +26,11 @@ export default function ModelRevisionsManager({ modelId }: { modelId: string }) 
     } catch {
       // ignore
     }
-  }
+  }, [modelId])
 
   useEffect(() => {
-    load()
-  }, [modelId])
+    void load()
+  }, [load])
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/components/PWAInstallPrompt.tsx
+++ b/components/PWAInstallPrompt.tsx
@@ -1,5 +1,5 @@
 "use client"
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
 type BeforeInstallPromptEvent = Event & {
   readonly platforms?: string[]
@@ -36,21 +36,21 @@ export default function PWAInstallPrompt() {
     return window.matchMedia('(display-mode: standalone)').matches || (window.navigator as Navigator & { standalone?: boolean }).standalone === true
   }
 
-  const persistDismissed = () => {
+  const persistDismissed = useCallback(() => {
     setDismissed(true)
     dismissedRef.current = true
     setShowIosPrompt(false)
     try { localStorage.setItem(STORAGE_KEY, '1') } catch {}
-  }
+  }, [])
 
-  const promptInstall = async (installEvent: BeforeInstallPromptEvent) => {
+  const promptInstall = useCallback(async (installEvent: BeforeInstallPromptEvent) => {
     await installEvent.prompt()
     const choice = await installEvent.userChoice
     setEvent(null)
     if (choice.outcome === 'accepted' || choice.outcome === 'dismissed') {
       persistDismissed()
     }
-  }
+  }, [persistDismissed])
 
   useEffect(() => {
     try {
@@ -84,7 +84,7 @@ export default function PWAInstallPrompt() {
 
     window.addEventListener('beforeinstallprompt', onBeforeInstall)
     return () => window.removeEventListener('beforeinstallprompt', onBeforeInstall)
-  }, [])
+  }, [promptInstall])
 
   const handleInstall = async () => {
     if (!event) return

--- a/components/admin/ModelManager.tsx
+++ b/components/admin/ModelManager.tsx
@@ -218,6 +218,7 @@ export default function ModelManager() {
                     <img
                       src={buildImageSrc(m.coverImagePath, m.updatedAt) || `/files${m.coverImagePath}`}
                       className="w-16 h-12 object-cover rounded border border-white/10"
+                      alt={`${m.title} cover`}
                     />
                   ) : (
                     <div className="w-16 h-12 bg-slate-900/60 rounded border border-white/10" />
@@ -254,7 +255,7 @@ export default function ModelManager() {
           <div className="p-3 grid md:grid-cols-12 gap-3 items-center">
             <div className="md:col-span-1">
               {activeModel.coverImagePath ? (
-                <img src={buildImageSrc(activeModel.coverImagePath, activeModel.updatedAt) || `/files${activeModel.coverImagePath}`} className="w-16 h-12 object-cover rounded border border-white/10" />
+                <img src={buildImageSrc(activeModel.coverImagePath, activeModel.updatedAt) || `/files${activeModel.coverImagePath}`} className="w-16 h-12 object-cover rounded border border-white/10" alt={`${activeModel.title} cover`} />
               ) : (
                 <div className="w-16 h-12 bg-slate-900/60 rounded border border-white/10" />
               )}

--- a/components/notifications/NotificationsProvider.tsx
+++ b/components/notifications/NotificationsProvider.tsx
@@ -32,21 +32,22 @@ export default function NotificationsProvider({ children }: { children: React.Re
   const [items, setItems] = useState<Notice[]>([])
   const timers = useRef<Record<string, any>>({})
 
-  const notify = useCallback((n: Omit<Notice, 'id'>) => {
-    const id = rndId()
-    const notice: Notice = { id, ...n }
-    setItems(prev => [...prev, notice])
-    const t = setTimeout(() => dismiss(id), n.timeout ?? (n.type === 'error' ? 8000 : 4000))
-    timers.current[id] = t
-  }, [])
-
   const dismiss = useCallback((id: string) => {
     setItems(prev => prev.filter(i => i.id !== id))
     const t = timers.current[id]
     if (t) { clearTimeout(t); delete timers.current[id] }
   }, [])
 
+  const notify = useCallback((n: Omit<Notice, 'id'>) => {
+    const id = rndId()
+    const notice: Notice = { id, ...n }
+    setItems(prev => [...prev, notice])
+    const t = setTimeout(() => dismiss(id), n.timeout ?? (n.type === 'error' ? 8000 : 4000))
+    timers.current[id] = t
+  }, [dismiss])
+
   useEffect(() => {
+    const currentTimers = timers.current
     const flushSessionQueue = () => {
       try {
         const raw = sessionStorage.getItem(SESSION_KEY)
@@ -79,7 +80,7 @@ export default function NotificationsProvider({ children }: { children: React.Re
     return () => {
       window.removeEventListener('storage', onStorage)
       window.removeEventListener(EVENT_KEY, onCustom as EventListener)
-      Object.values(timers.current).forEach(clearTimeout)
+      Object.values(currentTimers).forEach(clearTimeout)
     }
   }, [notify])
 


### PR DESCRIPTION
### Motivation
- Improve client-side robustness by eliminating stale-closure and effect dependency patterns and addressing accessibility gaps found during an audit.
- Reduce risk of subtle runtime bugs from un-memoized callbacks, unstable effect dependencies, and notification timer leaks.

### Description
- Added `alt` attributes to profile avatar and admin model cover images to close accessibility gaps in `app/settings/profile/page.tsx` and `components/admin/ModelManager.tsx`.
- Converted the revision loader in `components/ModelRevisionsManager.tsx` to a `useCallback` and wired the `useEffect` to that stable callback to avoid stale dependencies.
- Memoized PWA install prompt handlers and made effect dependencies explicit in `components/PWAInstallPrompt.tsx` to stabilize lifecycle behavior.
- Reordered and stabilized notification dismiss/notify callbacks and captured timer references for safe cleanup in `components/notifications/NotificationsProvider.tsx` to prevent stale-ref/timeouts during unmounts.

### Testing
- Ran `npm run lint`, which completed with no errors (remaining pre-existing warnings are unrelated to these changes).
- Ran `npm run typecheck`, which completed successfully with no type errors.
- Ran `npm test`, which executed the test runner (no failing suites related to these UI changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f07d35c344832f9220a226537cd8b2)

## Summary by Sourcery

Improve client-side notification, PWA install prompt, and model revisions loading behavior while addressing minor accessibility gaps in profile and admin UIs.

Bug Fixes:
- Ensure notification timeouts are properly tracked and cleared on unmount to avoid stale timers.
- Stabilize PWA install prompt behavior by memoizing install and dismissal handlers and tightening effect dependencies.
- Prevent stale model revision fetches by memoizing the loader and wiring the effect to the stable callback.
- Improve accessibility for profile avatars and admin model cover images by adding descriptive alt text.