### PR TITLE
Add Canada Day holiday theme with confetti animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1063,6 +1063,18 @@ html.theme-light body.holiday-maythefourth {
     #e5edf7;
   color: #111827;
 }
+html.theme-light body.holiday-canadaday {
+  background:
+    linear-gradient(
+      90deg,
+      rgba(220, 38, 38, 0.12) 0 18%,
+      rgba(255, 255, 255, 0.98) 18% 82%,
+      rgba(220, 38, 38, 0.12) 82% 100%
+    ),
+    radial-gradient(1000px 600px at 50% -20%, rgba(239, 68, 68, 0.16), transparent),
+    #fffdfd;
+  color: #1f2937;
+}
 body.holiday-valentines {
   background:
     radial-gradient(900px 520px at 82% -15%, rgba(244, 63, 94, 0.25), transparent),
@@ -1075,6 +1087,17 @@ body.holiday-maythefourth {
     radial-gradient(1200px 700px at 50% -30%, rgba(59, 130, 246, 0.16), transparent),
     radial-gradient(700px 420px at 0% 0%, rgba(148, 163, 184, 0.08), transparent),
     linear-gradient(160deg, #01040a 0%, #060b15 48%, #0d1421 100%);
+}
+body.holiday-canadaday {
+  background:
+    linear-gradient(
+      90deg,
+      rgba(127, 29, 29, 0.45) 0 16%,
+      rgba(255, 255, 255, 0.06) 16% 84%,
+      rgba(127, 29, 29, 0.45) 84% 100%
+    ),
+    radial-gradient(980px 620px at 50% -25%, rgba(239, 68, 68, 0.22), transparent),
+    linear-gradient(160deg, #180406 0%, #2a090d 42%, #3f0b0f 100%);
 }
 html.theme-light body.holiday-easter .glass {
   background: rgba(255, 255, 255, 0.85);
@@ -1091,6 +1114,9 @@ html.theme-light body.holiday-halloween .btn {
 }
 html.theme-light body.holiday-valentines .btn {
   box-shadow: 0 8px 25px rgba(244, 63, 94, 0.3);
+}
+html.theme-light body.holiday-canadaday .btn {
+  box-shadow: 0 8px 24px rgba(220, 38, 38, 0.25);
 }
 
 .holiday-effects {
@@ -1319,6 +1345,41 @@ html.theme-light body.holiday-valentines .btn {
   20% { opacity: 0.7; }
   70% { transform: translate3d(0.5vw, 70vh, 0) rotate(6deg) scale(1.05); opacity: 0.85; }
   100% { transform: translate3d(1vw, 120vh, 0) rotate(2deg) scale(0.98); opacity: 0; }
+}
+
+.holiday-canada-confetti {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(254, 226, 226, 0.96));
+  border: 1px solid rgba(220, 38, 38, 0.75);
+  border-radius: 2px;
+  box-shadow: 0 0 10px rgba(220, 38, 38, 0.32);
+  animation-iteration-count: infinite;
+}
+.holiday-canada-confetti[data-tone="0"],
+.holiday-canada-confetti[data-tone="2"],
+.holiday-canada-confetti[data-tone="4"] {
+  background: linear-gradient(170deg, rgba(254, 226, 226, 0.95), rgba(220, 38, 38, 0.95));
+}
+.holiday-canada-confetti[data-variant="0"] { animation-name: holiday-canada-fall-left; }
+.holiday-canada-confetti[data-variant="1"] { animation-name: holiday-canada-fall-right; }
+.holiday-canada-confetti[data-variant="2"] { animation-name: holiday-canada-fall-center; }
+@keyframes holiday-canada-fall-left {
+  0% { transform: translate3d(4vw, -16vh, 0) rotate(-16deg) scale(0.82); opacity: 0; }
+  25% { opacity: 0.78; }
+  62% { transform: translate3d(-2vw, 58vh, 0) rotate(14deg) scale(1); opacity: 0.9; }
+  100% { transform: translate3d(-6vw, 122vh, 0) rotate(-8deg) scale(0.9); opacity: 0; }
+}
+@keyframes holiday-canada-fall-right {
+  0% { transform: translate3d(-4vw, -14vh, 0) rotate(14deg) scale(0.84); opacity: 0; }
+  28% { opacity: 0.8; }
+  66% { transform: translate3d(2vw, 62vh, 0) rotate(-12deg) scale(1.05); opacity: 0.92; }
+  100% { transform: translate3d(6vw, 122vh, 0) rotate(9deg) scale(0.92); opacity: 0; }
+}
+@keyframes holiday-canada-fall-center {
+  0% { transform: translate3d(0, -15vh, 0) rotate(-8deg) scale(0.86); opacity: 0; }
+  22% { opacity: 0.76; }
+  70% { transform: translate3d(1vw, 72vh, 0) rotate(10deg) scale(1.04); opacity: 0.9; }
+  100% { transform: translate3d(2vw, 122vh, 0) rotate(-3deg) scale(0.95); opacity: 0; }
 }
 
 .holiday-mtf-scene {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -41,7 +41,10 @@ function resolveHolidayTheme(): HolidayTheme | null {
   if (raw === 'may the fourth' || raw === 'may-the-fourth' || raw === 'may_the_fourth') {
     return 'maythefourth'
   }
-  if (raw === 'christmas' || raw === 'halloween' || raw === 'easter' || raw === 'valentines' || raw === 'maythefourth') {
+  if (raw === 'canada day' || raw === 'canada-day' || raw === 'canada_day') {
+    return 'canadaday'
+  }
+  if (raw === 'christmas' || raw === 'halloween' || raw === 'easter' || raw === 'valentines' || raw === 'maythefourth' || raw === 'canadaday') {
     return raw
   }
   return null

--- a/components/HolidayEffects.tsx
+++ b/components/HolidayEffects.tsx
@@ -1,7 +1,7 @@
 "use client"
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 
-export type HolidayTheme = 'christmas' | 'halloween' | 'easter' | 'valentines' | 'maythefourth'
+export type HolidayTheme = 'christmas' | 'halloween' | 'easter' | 'valentines' | 'maythefourth' | 'canadaday'
 type ParticleTheme = Exclude<HolidayTheme, 'maythefourth'>
 type Ship = 'xwing' | 'tie'
 
@@ -54,6 +54,7 @@ const CONFIG: Record<ParticleTheme, ParticleConfig> = {
   halloween: { count: 26, className: 'holiday-halloween-candy', minSize: 6, maxSize: 14 },
   easter: { count: 3, className: 'holiday-easter-egg', minSize: 72, maxSize: 132 },
   valentines: { count: 34, className: 'holiday-valentines-candy', minSize: 8, maxSize: 18 },
+  canadaday: { count: 30, className: 'holiday-canada-confetti', minSize: 8, maxSize: 20 },
 }
 
 function rand(min: number, max: number): number {


### PR DESCRIPTION
### Motivation
- Provide a Canada Day (red/white) visual theme and optional screen animation to celebrate the holiday.

### Description
- Add `canadaday` to the `HolidayTheme` union and include it in the particle `CONFIG` so particles render as Canada-themed confetti (components/HolidayEffects.tsx).
- Accept common `HOLIDAY_THEME` environment variants (`canada day`, `canada-day`, `canada_day`, `canadaday`) in `resolveHolidayTheme` (app/layout.tsx).
- Add light and dark background treatments and a light-theme button shadow tweak for the Canada Day theme (app/globals.css).
- Implement `holiday-canada-confetti` CSS with three keyframe motions to animate red/white confetti particles across the screen (app/globals.css).

### Testing
- Ran `npm run -s typecheck`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4b2b5790c832f9dbc2a8a1a7ce78e)

## Summary by Sourcery

Add a Canada Day holiday theme with matching confetti particle effects and environment configuration support.

New Features:
- Introduce a Canada Day holiday theme variant across the app, including particle effects and environment variable handling for common name variants.

Enhancements:
- Add dedicated light and dark background treatments and button styling for the Canada Day holiday theme.
- Implement Canada Day confetti particle styling and animations to render red and white falling confetti.